### PR TITLE
Adding long support

### DIFF
--- a/src/main/java/org/fulib/yaml/Reflector.java
+++ b/src/main/java/org/fulib/yaml/Reflector.java
@@ -195,6 +195,21 @@ public class Reflector
       {
          // e.printStackTrace();
       }
+
+      // maybe a huge number
+      try {
+         long longValue = Long.parseLong((String) value);
+         Class<?> clazz = Class.forName(className);
+
+         Method method = clazz.getMethod("set" + StrUtil.cap(attribute), long.class);
+
+         method.invoke(object, longValue);
+
+         return true;
+      } catch (Exception e) {
+         // e.printStackTrace(); // I don't like this :(
+      }
+
       // maybe a double
       try
       {


### PR DESCRIPTION
When trying to serialize/deserialize long numbers, I noticed that these numbers are not correctly deserialized because `Reflector` only handles `int`, `double` and `float`.

Serialization works fine.

This PR should fix that.