### PR TITLE
OpenJDK instead of OracleJDK in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 install: true
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - "./gradlew test"
 after_success:


### PR DESCRIPTION
# Added Openjdk to travis.yml
This Pullrequest should fix the failed build in commit [bda48ac](https://github.com/fujaba/fulibYaml/commit/bda48acea3456be56d5bbf655b25cf03c271ef44)

The error message was `Expected feature release number in range of 9 to 14, but got: 8`.
