### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repositories {
 ```groovy
 dependencies {
    // https://mvnrepository.com/artifact/org.fulib/fulibYaml
-   compile group: 'org.fulib', name: 'fulibYaml', version: '1.5.0'
+   implementation group: 'org.fulib', name: 'fulibYaml', version: '1.5.0'
 }
 ```
 


### PR DESCRIPTION
For the new Gradle version I think rather than `compile`, it should be `implementation`.